### PR TITLE
Removed pull_request.number from concurrency group

### DIFF
--- a/.github/workflows/ctest.yaml
+++ b/.github/workflows/ctest.yaml
@@ -20,6 +20,7 @@ on:
 
 # Abort running jobs if a new one is triggered
 concurrency:
+  # github.ref = refs/heads/<branch_name> for push or refs/pull/<pr_number>/merge for pull request
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 

--- a/.github/workflows/ctest.yaml
+++ b/.github/workflows/ctest.yaml
@@ -20,7 +20,7 @@ on:
 
 # Abort running jobs if a new one is triggered
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel


### PR DESCRIPTION
Because it cancels pull request workflows after pushing new commits to PR branch

Since https://docs.github.com/en/actions/learn-github-actions/contexts#github-context says about github.ref  "For workflows triggered by pull_request, this is the pull request merge branch." and "For other triggers, this is the branch or tag ref that triggered the workflow run.", and ". The ref given is fully-formed, meaning that for branches the format is refs/heads/<branch_name>, for pull requests it is refs/pull/<pr_number>/merge" this should work (i.e. github.ref should not be the same for push and pull_request)