### PR TITLE
Generate UML diagrams with doxygen

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -29,6 +29,8 @@ jobs:
         doxyfile-path: "./Doxyfile" # default is ./Doxyfile
         # Working directory
         working-directory: "." # default is .
+        # Dependency for creating UML class/collaboration diagrams
+        additional-packages: graphviz
     
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3

--- a/Doxyfile
+++ b/Doxyfile
@@ -2263,7 +2263,7 @@ HIDE_UNDOC_RELATIONS   = YES
 # set to NO
 # The default value is: YES.
 
-HAVE_DOT               = NO
+HAVE_DOT               = YES
 
 # The DOT_NUM_THREADS specifies the number of dot invocations doxygen is allowed
 # to run in parallel. When set to 0 doxygen will base this on the number of


### PR DESCRIPTION
Tested locally using [nektos/gh-act](https://github.com/nektos/gh-act) (`$ gh act`).  
Closes #21.

(Currently generates the more minimal collaboration diagram type.  
Set `UML_LOOK = YES` [here](https://github.com/HSU-HPC/MaMiCo/blob/e45feab6a08dd72945257a9b4c2280aa6dabb399/Doxyfile#L2332) to generate full class diagrams instead.)