### PR TITLE
Fixed: IndexingService did not work correctly if BUILD_WITH_MPI=OFF

### DIFF
--- a/coupling/indexing/IndexingService.cpp
+++ b/coupling/indexing/IndexingService.cpp
@@ -433,8 +433,7 @@ void coupling::indexing::IndexingService<dim>::init(tarch::la::Vector<dim, unsig
   CellIndex<dim, IndexTrait::vector, IndexTrait::md2macro>::upperBoundary = CellIndex<dim, IndexTrait::md2macro>::upperBoundary;
   CellIndex<dim, IndexTrait::vector, IndexTrait::md2macro>::setDomainParameters();
 
-// handle all local indexing types
-#if (COUPLING_MD_PARALLEL == COUPLING_MD_YES) // parallel scenario
+  // handle all local indexing types
 
   _numberProcesses = numberProcesses;
 
@@ -531,52 +530,8 @@ void coupling::indexing::IndexingService<dim>::init(tarch::la::Vector<dim, unsig
   CellIndex<dim, IndexTrait::vector, IndexTrait::local, IndexTrait::md2macro>::upperBoundary =
       CellIndex<dim, IndexTrait::local, IndexTrait::md2macro>::upperBoundary;
   CellIndex<dim, IndexTrait::vector, IndexTrait::local, IndexTrait::md2macro>::setDomainParameters();
-
-#else // sequential scenario
-      // Copy all local indexing from global
-  CellIndex<dim, IndexTrait::local>::lowerBoundary = CellIndex<dim>::lowerBoundary;
-  CellIndex<dim, IndexTrait::local>::upperBoundary = CellIndex<dim>::upperBoundary;
-  CellIndex<dim, IndexTrait::local>::setDomainParameters();
-
-  CellIndex<dim, IndexTrait::vector, IndexTrait::local>::lowerBoundary = CellIndex<dim, IndexTrait::vector>::lowerBoundary;
-  CellIndex<dim, IndexTrait::vector, IndexTrait::local>::upperBoundary = CellIndex<dim, IndexTrait::vector>::upperBoundary;
-  CellIndex<dim, IndexTrait::vector, IndexTrait::local>::setDomainParameters();
-
-  CellIndex<dim, IndexTrait::local, IndexTrait::noGhost>::lowerBoundary = CellIndex<dim, IndexTrait::noGhost>::lowerBoundary;
-  CellIndex<dim, IndexTrait::local, IndexTrait::noGhost>::upperBoundary = CellIndex<dim, IndexTrait::noGhost>::upperBoundary;
-  CellIndex<dim, IndexTrait::local, IndexTrait::noGhost>::setDomainParameters();
-
-  CellIndex<dim, IndexTrait::vector, IndexTrait::local, IndexTrait::noGhost>::lowerBoundary =
-      CellIndex<dim, IndexTrait::vector, IndexTrait::noGhost>::lowerBoundary;
-  CellIndex<dim, IndexTrait::vector, IndexTrait::local, IndexTrait::noGhost>::upperBoundary =
-      CellIndex<dim, IndexTrait::vector, IndexTrait::noGhost>::upperBoundary;
-  CellIndex<dim, IndexTrait::vector, IndexTrait::local, IndexTrait::noGhost>::setDomainParameters();
-
-  CellIndex<dim, IndexTrait::local, IndexTrait::md2macro>::lowerBoundary = CellIndex<dim, IndexTrait::md2macro>::lowerBoundary;
-  CellIndex<dim, IndexTrait::local, IndexTrait::md2macro>::upperBoundary = CellIndex<dim, IndexTrait::md2macro>::upperBoundary;
-  CellIndex<dim, IndexTrait::local, IndexTrait::md2macro>::setDomainParameters();
-
-  CellIndex<dim, IndexTrait::vector, IndexTrait::local, IndexTrait::md2macro>::lowerBoundary =
-      CellIndex<dim, IndexTrait::vector, IndexTrait::md2macro>::lowerBoundary;
-  CellIndex<dim, IndexTrait::vector, IndexTrait::local, IndexTrait::md2macro>::upperBoundary =
-      CellIndex<dim, IndexTrait::vector, IndexTrait::md2macro>::upperBoundary;
-  CellIndex<dim, IndexTrait::vector, IndexTrait::local, IndexTrait::md2macro>::setDomainParameters();
-
-  CellIndex<dim, IndexTrait::local, IndexTrait::md2macro, IndexTrait::noGhost>::lowerBoundary =
-      CellIndex<dim, IndexTrait::md2macro, IndexTrait::noGhost>::lowerBoundary;
-  CellIndex<dim, IndexTrait::local, IndexTrait::md2macro, IndexTrait::noGhost>::upperBoundary =
-      CellIndex<dim, IndexTrait::md2macro, IndexTrait::noGhost>::upperBoundary;
-  CellIndex<dim, IndexTrait::local, IndexTrait::md2macro, IndexTrait::noGhost>::setDomainParameters();
-
-  CellIndex<dim, IndexTrait::vector, IndexTrait::local, IndexTrait::md2macro, IndexTrait::noGhost>::lowerBoundary =
-      CellIndex<dim, IndexTrait::vector, IndexTrait::md2macro, IndexTrait::noGhost>::lowerBoundary;
-  CellIndex<dim, IndexTrait::vector, IndexTrait::local, IndexTrait::md2macro, IndexTrait::noGhost>::upperBoundary =
-      CellIndex<dim, IndexTrait::vector, IndexTrait::md2macro, IndexTrait::noGhost>::upperBoundary;
-  CellIndex<dim, IndexTrait::vector, IndexTrait::local, IndexTrait::md2macro, IndexTrait::noGhost>::setDomainParameters();
-#endif
 }
 
-#if (COUPLING_MD_PARALLEL == COUPLING_MD_YES) // unused in sequential scenario
 /*
  * This was in large parts stolen from IndexConversion.
  */
@@ -645,9 +600,7 @@ std::vector<unsigned int> coupling::indexing::IndexingService<dim>::getRanksForG
 
   return ranks;
 }
-#endif
 
-#if (COUPLING_MD_PARALLEL == COUPLING_MD_YES) // unused in sequential scenario
 /*
  * This was in large parts stolen from IndexConversion.
  * Note that this uses the globalNumberMacroscopicCells definition excl. the
@@ -692,7 +645,6 @@ coupling::indexing::IndexingService<dim>::getUniqueRankForMacroscopicCell(tarch:
 
   return _parallelTopology->getRank(processCoords);
 }
-#endif
 
 // declare specialisation of IndexingService
 #ifdef INDEXING_ENABLE_DIM2

--- a/coupling/indexing/IndexingService.h
+++ b/coupling/indexing/IndexingService.h
@@ -110,7 +110,6 @@ public:
 #endif
   }
 
-#if (COUPLING_MD_PARALLEL == COUPLING_MD_YES) // parallel scenario
   /**
    * Determines all ranks that contain a certain global BaseIndex.
    * Ripped from deprecated IndexConversion.
@@ -122,6 +121,7 @@ public:
    */
   std::vector<unsigned int> getRanksForGlobalIndex(const BaseIndex<dim>& globalCellIndex) const;
 
+#if (COUPLING_MD_PARALLEL == COUPLING_MD_YES) // parallel scenario
   MPI_Comm getComm() const {
 #if (COUPLING_MD_ERROR == COUPLING_MD_YES)
     if (!_isInitialized) {
@@ -148,7 +148,6 @@ public:
 #endif
 
 private:
-#if (COUPLING_MD_PARALLEL == COUPLING_MD_YES) // parallel scenario
   /**
    * Helper function used by getRanksForGlobalIndex().
    */
@@ -158,6 +157,7 @@ private:
 
   /*const*/ tarch::la::Vector<dim, unsigned int> _numberProcesses; // TODO: make const
   const coupling::paralleltopology::ParallelTopology<dim>* _parallelTopology;
+#if (COUPLING_MD_PARALLEL == COUPLING_MD_YES) // parallel scenario
   MPI_Comm _comm;
 #endif
   unsigned int _rank;

--- a/test/unit/coupling/indexing/IndexingServiceTest.cpp
+++ b/test/unit/coupling/indexing/IndexingServiceTest.cpp
@@ -354,12 +354,10 @@ public:
 
     service.init({12}, {2, 1, 1}, coupling::paralleltopology::XYZ, 3, 0u);
 
-#if (COUPLING_MD_PARALLEL == COUPLING_MD_YES)
     // out of domain
     CPPUNIT_ASSERT_THROW(service.getUniqueRankForMacroscopicCell({1, 14, 1}, {12}), std::runtime_error);
     CPPUNIT_ASSERT_EQUAL(service.getUniqueRankForMacroscopicCell({1, 1, 1}, {12}), 0u);
     CPPUNIT_ASSERT_EQUAL(service.getUniqueRankForMacroscopicCell({7, 1, 1}, {12}), 1u);
-#endif
   }
 
 private:

--- a/test/unit/coupling/indexing/IndexingServiceTest.cpp
+++ b/test/unit/coupling/indexing/IndexingServiceTest.cpp
@@ -354,11 +354,12 @@ public:
 
     service.init({12}, {2, 1, 1}, coupling::paralleltopology::XYZ, 3, 0u);
 
+#if (COUPLING_MD_PARALLEL == COUPLING_MD_YES)
     // out of domain
     CPPUNIT_ASSERT_THROW(service.getUniqueRankForMacroscopicCell({1, 14, 1}, {12}), std::runtime_error);
-
     CPPUNIT_ASSERT_EQUAL(service.getUniqueRankForMacroscopicCell({1, 1, 1}, {12}), 0u);
     CPPUNIT_ASSERT_EQUAL(service.getUniqueRankForMacroscopicCell({7, 1, 1}, {12}), 1u);
+#endif
   }
 
 private:


### PR DESCRIPTION
This fixes:

- IndexingServiceTest failed to compile if BUILD_WITH_MPI=OFF
- IndexingService did not use numberProcesses when BUILD_WITH_MPI=OFF (thus parallel indexing was not usable in a sequential build; but we do that / test that)