### PR TITLE
Mdsolver test exclude

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -791,7 +791,7 @@ endif()
 #
 if (BUILD_TESTING)    
   file(GLOB_RECURSE TEST_SOURCES_TOP "test/*Test.cpp")
-  list(FILTER TEST_SOURCES_TOP EXCLUDE REGEX "impl") # remove tests corresponding to specific MD solvers
+  list(FILTER TEST_SOURCES_TOP EXCLUDE REGEX "test/unit/coupling/interface/impl/") # remove tests corresponding to specific MD solvers
   
   if("${MD_SIM}" STREQUAL "SIMPLE_MD")
     file(GLOB_RECURSE TEST_SOURCES_MD "test/unit/coupling/interface/impl/SimpleMD/*Test.cpp")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -790,8 +790,20 @@ endif()
 # Testing
 #
 if (BUILD_TESTING)    
-  file(GLOB_RECURSE TEST_SOURCES "test/*Test.cpp")
+  file(GLOB_RECURSE TEST_SOURCES_TOP "test/*Test.cpp")
+  list(FILTER TEST_SOURCES_TOP EXCLUDE REGEX "impl") # remove tests corresponding to specific MD solvers
+  
+  if("${MD_SIM}" STREQUAL "SIMPLE_MD")
+    file(GLOB_RECURSE TEST_SOURCES_MD "test/unit/coupling/interface/impl/SimpleMD/*Test.cpp")
+  elseif("${MD_SIM}" STREQUAL "LS1_MARDYN")
+    file(GLOB_RECURSE TEST_SOURCES_MD "test/unit/coupling/interface/impl/ls1/*Test.cpp")
+  elseif("${MD_SIM}" STREQUAL "LAMMPS_MD" OR "${MD_SIM}" STREQUAL "LAMMPS_DPD")
+    file(GLOB_RECURSE TEST_SOURCES_MD "test/unit/coupling/interface/impl/LAMMPS/*Test.cpp")
+  else()
+    message(FATAL_ERROR "Could not determine the MD solver while compiling tests")
+  endif()
 
+  set(TEST_SOURCES ${TEST_SOURCES_TOP} ${TEST_SOURCES_MD})
   if(GET_TEST_NAMES)
     add_executable(getTestNames
       ${MAMICO_SOURCES}

--- a/coupling/interface/Molecule.h
+++ b/coupling/interface/Molecule.h
@@ -5,6 +5,8 @@
 #ifndef _MOLECULARDYNAMICS_COUPLING_INTERFACE_MOLECULE_H_
 #define _MOLECULARDYNAMICS_COUPLING_INTERFACE_MOLECULE_H_
 
+#include "tarch/la/Vector.h"
+
 namespace coupling {
 namespace interface {
 template <unsigned int dim> class Molecule;

--- a/coupling/interface/impl/ls1/LS1StaticCommData.h
+++ b/coupling/interface/impl/ls1/LS1StaticCommData.h
@@ -1,9 +1,7 @@
 #ifndef LS1_STATIC_COMM_DATA_H_
 #define LS1_STATIC_COMM_DATA_H_
 
-//possibly bad practice? will phase out
 #include <string>
-#include <iostream>
 #if (COUPLING_MD_PARALLEL == COUPLING_MD_YES)
 #include <mpi.h>
 #endif

--- a/test/unit/coupling/interface/impl/README.txt
+++ b/test/unit/coupling/interface/impl/README.txt
@@ -1,0 +1,3 @@
+Tests in this folder are only compiled if the respective MD_SIM is active
+
+If new folders are created in this folder in the future, do remember to update CMakeLists.txt accordingly

--- a/test/unit/coupling/interface/impl/SimpleMD/SimpleMDMoleculeTest.cpp
+++ b/test/unit/coupling/interface/impl/SimpleMD/SimpleMDMoleculeTest.cpp
@@ -38,7 +38,9 @@ public:
 
 					simpleMolecule.setVelocity(velocity);
 					tarch::la::Vector<3,double> storedVelocity = simpleMolecule.getVelocity();
-					CPPUNIT_ASSERT_MESSAGE( "velocity assersion",storedVelocity == velocity );
+					CPPUNIT_ASSERT_DOUBLES_EQUAL_MESSAGE( "velocity assertion x",storedVelocity[0], velocity[0], 1e-6 );
+					CPPUNIT_ASSERT_DOUBLES_EQUAL_MESSAGE( "velocity assertion y",storedVelocity[1], velocity[1], 1e-6 );
+					CPPUNIT_ASSERT_DOUBLES_EQUAL_MESSAGE( "velocity assertion z",storedVelocity[2], velocity[2], 1e-6 );
 				}
 			}
 		}
@@ -57,7 +59,9 @@ public:
 
 					simpleMolecule.setForce(force);
 					tarch::la::Vector<3,double> storedForce = simpleMolecule.getForce();
-					CPPUNIT_ASSERT_MESSAGE( "force assersion",storedForce == force );
+					CPPUNIT_ASSERT_DOUBLES_EQUAL_MESSAGE( "force assertion x",storedForce[0], force[0], 1e-6 );
+					CPPUNIT_ASSERT_DOUBLES_EQUAL_MESSAGE( "force assertion y",storedForce[1], force[1], 1e-6 );
+					CPPUNIT_ASSERT_DOUBLES_EQUAL_MESSAGE( "force assertion z",storedForce[2], force[2], 1e-6 );
 				}
 			}
 		}

--- a/test/unit/coupling/interface/impl/SimpleMD/SimpleMDMoleculeTest.cpp
+++ b/test/unit/coupling/interface/impl/SimpleMD/SimpleMDMoleculeTest.cpp
@@ -1,0 +1,67 @@
+#include <cppunit/TestFixture.h>
+#include <cppunit/extensions/HelperMacros.h>
+
+#include "coupling/interface/impl/SimpleMD/SimpleMDMolecule.h"
+
+#include "simplemd/Molecule.h"
+#include "tarch/la/Vector.h"
+
+#include <sstream>
+
+class SimpleMDMoleculeTest : public CppUnit::TestFixture
+{
+	CPPUNIT_TEST_SUITE(SimpleMDMoleculeTest);
+	CPPUNIT_TEST(testVelocity);
+	CPPUNIT_TEST(testForce);
+	CPPUNIT_TEST_SUITE_END();
+
+public:
+	void setUp()
+	{
+		
+	}
+	void tearDown()
+	{
+
+	}
+	void testVelocity()
+	{
+		simplemd::Molecule myMolecule;
+		coupling::interface::SimpleMDMolecule simpleMolecule(&myMolecule);
+		for(int i = -4000; i < 4001; i+=100)
+		{
+			for(int j = -4000; j < 4001; j+=100)
+			{
+				for(int k = -4000; k < 4001; k+=100)
+				{
+					tarch::la::Vector<3,double> velocity{i+0.5,j+0.5,k+0.5};
+
+					simpleMolecule.setVelocity(velocity);
+					tarch::la::Vector<3,double> storedVelocity = simpleMolecule.getVelocity();
+					CPPUNIT_ASSERT_MESSAGE( "velocity assersion",storedVelocity == velocity );
+				}
+			}
+		}
+	}
+	void testForce()
+	{
+		simplemd::Molecule myMolecule;
+		coupling::interface::SimpleMDMolecule simpleMolecule(&myMolecule);
+		for(int i = -4000; i < 4001; i+=100)
+		{
+			for(int j = -4000; j < 4001; j+=100)
+			{
+				for(int k = -4000; k < 4001; k+=100)
+				{
+					tarch::la::Vector<3,double> force{i+0.5,j+0.5,k+0.5};
+
+					simpleMolecule.setForce(force);
+					tarch::la::Vector<3,double> storedForce = simpleMolecule.getForce();
+					CPPUNIT_ASSERT_MESSAGE( "force assersion",storedForce == force );
+				}
+			}
+		}
+	}
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(SimpleMDMoleculeTest);

--- a/test/unit/coupling/interface/impl/ls1/LS1StaticCommDataTest.cpp
+++ b/test/unit/coupling/interface/impl/ls1/LS1StaticCommDataTest.cpp
@@ -15,7 +15,11 @@ class LS1StaticCommDataTest : public CppUnit::TestFixture
 {
 	CPPUNIT_TEST_SUITE(LS1StaticCommDataTest);
 	CPPUNIT_TEST(testSerialFunctions);
+
+#if (COUPLING_MD_PARALLEL == COUPLING_MD_YES)
 	CPPUNIT_TEST(testParallelFunctions);
+#endif
+
 	CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -39,9 +43,10 @@ public:
 		for(int i = 0; i < 3; i++)
 			CPPUNIT_ASSERT( coupling::interface::LS1StaticCommData::getInstance().getBoxOffsetAtDim(i) == offsets[i] );
 	}
+
+#if (COUPLING_MD_PARALLEL == COUPLING_MD_YES)
 	void testParallelFunctions()
 	{
-#if (COUPLING_MD_PARALLEL == COUPLING_MD_YES)
 		int rank, size;
 		MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 		MPI_Comm_size(MPI_COMM_WORLD, &size);
@@ -59,8 +64,8 @@ public:
 				&& coupling::interface::LS1StaticCommData::getInstance().getDomainGridDecomp()[1] == gridDec[1] 
 				&& coupling::interface::LS1StaticCommData::getInstance().getDomainGridDecomp()[2] == gridDec[2] );
 		MPI_Comm_free(&comm);
-#endif
 	}
+#endif
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(LS1StaticCommDataTest);

--- a/test/unit/coupling/interface/impl/ls1/LS1StaticCommDataTest.cpp
+++ b/test/unit/coupling/interface/impl/ls1/LS1StaticCommDataTest.cpp
@@ -1,0 +1,66 @@
+#include <cppunit/TestFixture.h>
+#include <cppunit/extensions/HelperMacros.h>
+
+#include "coupling/interface/impl/ls1/LS1StaticCommData.h"
+
+#include <array>
+
+#if (COUPLING_MD_PARALLEL == COUPLING_MD_YES)
+#include <mpi.h>
+#endif
+
+#define MY_LINKEDCELL ls1::LS1RegionWrapper
+
+class LS1StaticCommDataTest : public CppUnit::TestFixture
+{
+	CPPUNIT_TEST_SUITE(LS1StaticCommDataTest);
+	CPPUNIT_TEST(testSerialFunctions);
+	CPPUNIT_TEST(testParallelFunctions);
+	CPPUNIT_TEST_SUITE_END();
+
+public:
+	void setUp()
+	{
+		
+	}
+	void tearDown()
+	{
+
+	}
+	void testSerialFunctions()
+	{
+		std::string filename = "test";
+		coupling::interface::LS1StaticCommData::getInstance().setConfigFilename(filename);
+		CPPUNIT_ASSERT( coupling::interface::LS1StaticCommData::getInstance().getConfigFilename() == filename );
+
+		std::array<double,3> offsets({5,5,5});
+		for(int i = 0; i < 3; i++)
+			coupling::interface::LS1StaticCommData::getInstance().setBoxOffsetAtDim(i,offsets[i]);
+		for(int i = 0; i < 3; i++)
+			CPPUNIT_ASSERT( coupling::interface::LS1StaticCommData::getInstance().getBoxOffsetAtDim(i) == offsets[i] );
+	}
+	void testParallelFunctions()
+	{
+#if (COUPLING_MD_PARALLEL == COUPLING_MD_YES)
+		int rank, size;
+		MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+		MPI_Comm_size(MPI_COMM_WORLD, &size);
+		MPI_Comm comm;
+		MPI_Comm_split(MPI_COMM_WORLD, rank, rank, &comm);
+		coupling::interface::LS1StaticCommData::getInstance().setLocalCommunicator(comm);
+		CPPUNIT_ASSERT( coupling::interface::LS1StaticCommData::getInstance().getLocalCommunicator() == comm );
+
+		std::array<int, 3> gridDec({2,1,4});
+		for(int i = 0; i < 3; i++)
+			coupling::interface::LS1StaticCommData::getInstance().setDomainGridDecompAtDim(i,gridDec[i]);
+		for(int i = 0; i < 3; i++)
+			CPPUNIT_ASSERT( coupling::interface::LS1StaticCommData::getInstance().getDomainGridDecompAtDim(i) == gridDec[i] );
+		CPPUNIT_ASSERT( coupling::interface::LS1StaticCommData::getInstance().getDomainGridDecomp()[0] == gridDec[0] 
+				&& coupling::interface::LS1StaticCommData::getInstance().getDomainGridDecomp()[1] == gridDec[1] 
+				&& coupling::interface::LS1StaticCommData::getInstance().getDomainGridDecomp()[2] == gridDec[2] );
+		MPI_Comm_free(&comm);
+#endif
+	}
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(LS1StaticCommDataTest);


### PR DESCRIPTION
Added checks in the CMakeLists to only compile tests for the currently selected MD solver. This circumvents having many ifdefs in all tests. I've added two sample tests to make sure it works.

If we'd rather have ifdefs, we can discuss it here.