### PR TITLE
Simplemd debug info

### DIFF
--- a/coupling/python-binding/mamico.cpp
+++ b/coupling/python-binding/mamico.cpp
@@ -182,7 +182,7 @@ int initMPI() {
   delete[] argv;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 #if defined(LS1_MARDYN)
-  Log::global_log = std::make_unique<Log::Logger>(Log::Error); //Log::Info
+  Log::global_log = std::make_unique<Log::Logger>(Log::Error); // Log::Info
 #if (COUPLING_MD_PARALLEL == COUPLING_MD_YES)
   global_log->set_mpi_output_root(0);
 #endif

--- a/coupling/scenario/CouetteScenario.h
+++ b/coupling/scenario/CouetteScenario.h
@@ -90,7 +90,7 @@ public:
    *  @brief initialises everthing necessary for the test */
   void init() override {
 #if defined(LS1_MARDYN)
-    Log::global_log = std::make_unique<Log::Logger>(Log::Error);; //Log::Info
+    Log::global_log = std::make_unique<Log::Logger>(Log::Error); // Log::Info
 #if (COUPLING_MD_PARALLEL == COUPLING_MD_YES)
     global_log->set_mpi_output_root(0);
 #endif

--- a/simplemd/molecule-mappings/UpdateLinkedCellListsMapping.cpp
+++ b/simplemd/molecule-mappings/UpdateLinkedCellListsMapping.cpp
@@ -29,9 +29,9 @@ void simplemd::moleculemappings::UpdateLinkedCellListsMapping::handleMolecule(Mo
       std::cout << "ERROR simplemd::moleculemappings::UpdateLinkedCellListsMapping::handleMolecule: Position ";
       std::cout << d << " is out of range!" << std::endl;
       std::cout << "Position: " << position << std::endl;
-      std::cout << molecule.getConstVelocity() << std::endl;
-      std::cout << molecule.getConstForce() << std::endl;
-      std::cout << molecule.getConstForceOld() << std::endl;
+      std::cout << "Velocity: " << molecule.getConstVelocity() << std::endl;
+      std::cout << "Force: " << molecule.getConstForce() << std::endl;
+      std::cout << "ForceOld: " << molecule.getConstForceOld() << std::endl;
       exit(EXIT_FAILURE);
     }
 #endif


### PR DESCRIPTION
This helped me to debug the checkpoint issue (misinterpretation of "periodic" boundaries with config file generator), I think it might be helpful again in the future, so it should be in master imo.

Only if CMAKE_BUILD_TYPE = DebugMD:
- Removed debug output for each force computation. This generated A LOT of output, making the DebugMD mode basically useless. It seems to come from an early SimpleMD development phase, I do not think it will be needed again in the future. Thus I removed it completely.
- Added extra debug output for very high forces, i.e. when two particles get too close to each other. The additional info in this case (position and IDs of the particles) will help to track down the cause of such issues