### PR TITLE
parameters like -numberLinkedCellsPerCouplingCell- deletes, cus they are not needed

### DIFF
--- a/coupling/interface/MDSimulationFactory.h
+++ b/coupling/interface/MDSimulationFactory.h
@@ -133,7 +133,7 @@ public:
       exit(EXIT_FAILURE);
     }
     mdSolverInterface = new coupling::interface::SimpleMDSolverInterface(
-        mamicoConfiguration.getCouplingCellConfiguration().getNumberLinkedCellsPerCouplingCell(), simpleMDSimulation->getBoundaryTreatment(),
+        simpleMDSimulation->getBoundaryTreatment(),
         simpleMDSimulation->getParallelTopologyService(), simpleMDSimulation->getMoleculeService(), simpleMDSimulation->getLinkedCellService(),
         simpleMDSimulation->getMolecularPropertiesService(), (simpleMDSimulation->getParallelTopologyService()).getLocalBoundaryInformation(),
         configuration.getSimulationConfiguration().getDt());

--- a/coupling/interface/impl/SimpleMD/SimpleMDSolverInterface.h
+++ b/coupling/interface/impl/SimpleMD/SimpleMDSolverInterface.h
@@ -37,7 +37,6 @@ private:
   const tarch::la::Vector<MD_LINKED_CELL_NEIGHBOURS, simplemd::BoundaryType>& _localBoundaryInformation;
 
   /** number of linked cells in each coupling cell */
-  const tarch::la::Vector<MD_DIM, unsigned int> _numberOfLinkedCellsPerCouplingCell;
 
   const double _sigma6;
   const double _epsilon;
@@ -101,14 +100,13 @@ private:
   }
 
 public:
-  SimpleMDSolverInterface(tarch::la::Vector<MD_DIM, unsigned int> numberLinkedCellsPerCouplingCell, simplemd::BoundaryTreatment& boundaryTreatment,
+  SimpleMDSolverInterface(simplemd::BoundaryTreatment& boundaryTreatment,
                           simplemd::services::ParallelTopologyService& parallelTopologyService, simplemd::services::MoleculeService& moleculeService,
                           simplemd::services::LinkedCellService& linkedCellService,
                           const simplemd::services::MolecularPropertiesService& molecularPropertiesService,
                           const tarch::la::Vector<MD_LINKED_CELL_NEIGHBOURS, simplemd::BoundaryType>& localBoundaryInformation, const double& dt)
       : _parallelTopologyService(parallelTopologyService), _moleculeService(moleculeService), _linkedCellService(linkedCellService),
         _molecularPropertiesService(molecularPropertiesService), _boundaryTreatment(boundaryTreatment), _localBoundaryInformation(localBoundaryInformation),
-        _numberOfLinkedCellsPerCouplingCell(numberLinkedCellsPerCouplingCell),
         _sigma6(molecularPropertiesService.getMolecularProperties().getSigma() * molecularPropertiesService.getMolecularProperties().getSigma() *
                 molecularPropertiesService.getMolecularProperties().getSigma() * molecularPropertiesService.getMolecularProperties().getSigma() *
                 molecularPropertiesService.getMolecularProperties().getSigma() * molecularPropertiesService.getMolecularProperties().getSigma()),

--- a/coupling/services/CouplingCellService.cpph
+++ b/coupling/services/CouplingCellService.cpph
@@ -67,7 +67,7 @@ coupling::services::CouplingCellServiceImpl<LinkedCell, dim>::CouplingCellServic
   }
 
   // init Usher parameters
-  initIndexVectors4Usher(couplingCellConfiguration.getNumberLinkedCellsPerCouplingCell());
+  initIndexVectors4Usher();
 
   // init vector of inner (MD Domain/non-ghost) cells and their indices
   // TODO: REMOVE
@@ -208,8 +208,7 @@ template <class LinkedCell, unsigned int dim> void coupling::services::CouplingC
 }
 
 template <class LinkedCell, unsigned int dim>
-void coupling::services::CouplingCellServiceImpl<LinkedCell, dim>::initIndexVectors4Usher(
-    tarch::la::Vector<dim, unsigned int> numberLinkedCellsPerCouplingCell) {
+void coupling::services::CouplingCellServiceImpl<LinkedCell, dim>::initIndexVectors4Usher() {
 
   const tarch::la::Vector<dim, unsigned int> firstNonGhostCouplingCell(1);
 

--- a/coupling/services/CouplingCellService.h
+++ b/coupling/services/CouplingCellService.h
@@ -280,7 +280,7 @@ private:
 #include "CouplingCellTraversalWrappers.cpph"
 
   /** initialises the index structures for USHER scheme */
-  void initIndexVectors4Usher(tarch::la::Vector<dim, unsigned int> numberLinkedCellsPerCouplingCell);
+  void initIndexVectors4Usher();
 
   tarch::la::Vector<dim, double> getPositionOfFirstLocalGhostCell() const;
 


### PR DESCRIPTION
some never used parameters in like numberLinkedCellsPerCouplingCell in the function initIndexVectors4Usher CouplingCellService.cpp are deleted