### PR TITLE
Fix/build couette with OpenFOAM in CI

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -48,8 +48,10 @@ jobs:
           key: OpenFOAM
       - name: Build couette executable
         run: |
-          ml gcc mpi || :
+          source scl_source enable gcc-toolset-9 || :
+          ml mpi || :
           ./tools/build-couette.py \
+            --force-gcc \
             --jobs $(($(nproc --all) / 2)) \
             --with-mpi \
             --with-foam \

--- a/tools/build-couette.py
+++ b/tools/build-couette.py
@@ -74,9 +74,10 @@ def git_clone_shallow(repository_url, repository_dir, branch):
 def build_ls1(mamico_repo_dir, with_mpi=False, jobs=8):
     print("Building ls1-MarDyn from source...")
     ls1_dir = mamico_repo_dir / "ls1"
-    if ls1_dir.exists():
-        # Avoid issues with initializing submodule
-        shutil.rmtree(ls1_dir)
+    # Appears to not be necessary
+    # if ls1_dir.exists():
+    #     # Avoid issues with initializing submodule
+    #     shutil.rmtree(ls1_dir)
     had_error = 0 != shell("git submodule init && git submodule update")
     if had_error != 0:
         return had_error
@@ -121,7 +122,10 @@ def download_open_foam():
                 OPEN_FOAM_THIRD_PARTY_URL, f"ThirdParty-v{OPEN_FOAM_VERSION}.tgz"
             )
             if not had_error:
-                shell(f"mv ThirdParty-v{OPEN_FOAM_VERSION} ThirdParty")
+                had_error = 0 != shell(f"mv ThirdParty-v{OPEN_FOAM_VERSION} ThirdParty")
+    if not had_error:
+        # Renamed unused logging macro to avoid issue when compiling MaMiCo with both OpenFOAM and ls1
+        had_error = 0 != shell(f"sed -i 's/^#define Log/#define FoamLog/g' {OPEN_FOAM_SRC_DIR}/src/OpenFOAM/lnInclude/messageStream.H")
     return had_error
 
 


### PR DESCRIPTION
Building `couette` with OpenFOAM [currently fail](https://github.com/HSU-HPC/MaMiCo/actions/runs/14196165245).  
There are at least two issues which are addressed in this PR:
+ ls1 collides with a macro in an OpenFOAM header :point_right: Rename macro in `build_couette.py`
+ There are errors when building OpenFOAM with GCC 13 (but GCC 9 seems to work locally) :point_right: Load GCC 9 instead