### PR TITLE
Fixed "all-in-one" build script for ls1

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -30,21 +30,18 @@ jobs:
         md-solver: [md, ls1] # lammps (LAMMPS integration is currently broken -> issue #86)
     steps:
       - name: Clean up any old files
-        run: |
-          rm -rf build
+        run: rm -rf build
       - uses: actions/checkout@v4
       - name: Use cached LAMMPS
         if: matrix.md-solver == 'lammps'
         uses: actions/cache/restore@v4
         with:
-          path: |
-            build/LAMMPS
+          path: build/LAMMPS
           key: LAMMPS
       - name: Use cached OpenFOAM
         uses: actions/cache/restore@v4
         with:
-          path: |
-            build/openfoam
+          path: build/openfoam
           key: OpenFOAM
       - name: Build couette executable
         run: |
@@ -60,18 +57,15 @@ jobs:
         uses: actions/cache/save@v4
         if: matrix.md-solver == 'lammps'
         with:
-          path: |
-            build/LAMMPS
+          path: build/LAMMPS
           key: LAMMPS
       - name: Cache OpenFOAM
         uses: actions/cache/save@v4
         with:
-          path: |
-            build/openfoam
+          path: build/openfoam
           key: OpenFOAM
       - name: Delete OpenFOAM files (too large)
-        run: |
-          rm -rf build/openfoam
+        run: rm -rf build/openfoam
       - uses: actions/upload-artifact@v4
         with:
           name: build-${{ runner.os }}-${{ runner.arch }}-${{ matrix.md-solver }}
@@ -89,8 +83,7 @@ jobs:
       - name: Use cached OpenFOAM
         uses: actions/cache/restore@v4
         with:
-          path: |
-            build/openfoam
+          path: build/openfoam
           key: OpenFOAM
       - uses: actions/download-artifact@v4
         with:

--- a/tools/build-couette.py
+++ b/tools/build-couette.py
@@ -85,7 +85,7 @@ def build_ls1(mamico_repo_dir, with_mpi=False, jobs=8, force_gcc=False):
     cmake_args = ""
     if force_gcc:
         cmake_args += f" -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc"
-    cmake_args += f"-S{ls1_dir} -B{build_dir}"
+    cmake_args += f" -S{ls1_dir} -B{build_dir}"
     cmake_args += " -DENABLE_ADIOS2=OFF"
     cmake_args += f" -DENABLE_MPI={'ON' if with_mpi else 'OFF'}"
     cmake_args += " -DOPENMP=OFF"


### PR DESCRIPTION
Fixes building couette with ls1 in [integration test workflow](https://github.com/HSU-HPC/MaMiCo/actions/runs/14267466913/job/39994627947#step:7:2310).