### PR TITLE
CI: Fail on cache timeout explicitly

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -38,11 +38,15 @@ jobs:
         with:
           path: build/LAMMPS
           key: LAMMPS
+          fail-on-cache-miss: true
       - name: Use cached OpenFOAM
         uses: actions/cache/restore@v4
         with:
           path: build/openfoam
           key: OpenFOAM
+          fail-on-cache-miss: true
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5 # Average cache transfer speed should be over 3 MB/s
       - name: Build couette executable
         run: |
           source scl_source enable gcc-toolset-9 || :

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -38,15 +38,11 @@ jobs:
         with:
           path: build/LAMMPS
           key: LAMMPS
-          fail-on-cache-miss: true
       - name: Use cached OpenFOAM
         uses: actions/cache/restore@v4
         with:
           path: build/openfoam
           key: OpenFOAM
-          fail-on-cache-miss: true
-        env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5 # Average cache transfer speed should be over 3 MB/s
       - name: Build couette executable
         run: |
           source scl_source enable gcc-toolset-9 || :
@@ -89,6 +85,9 @@ jobs:
         with:
           path: build/openfoam
           key: OpenFOAM
+          fail-on-cache-miss: true
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5 # Average cache transfer speed should be over 3 MB/s
       - uses: actions/download-artifact@v4
         with:
           name: build-${{ runner.os }}-${{ runner.arch }}-${{ matrix.solver_md }}


### PR DESCRIPTION
The integration tests workflow caches OpenFOAM which exceeds 800 MB.
I suspect this is the reason for why it sometimes [experiences a timeout, resulting in a cache miss](https://github.com/HSU-HPC/MaMiCo/actions/runs/15856675634/job/44706667172#step:4:174).
Therefore, I added an explicit timeout using environment variables and force the run to fail on a cache miss.

I also considered LZMA compression to bring the size of the cache below 500 MB:
```yaml
# In build-executable job
      - name: Compress OpenFOAM for caching
        run: |
          tar -cJf build/openfoam.tar.xz -C build/ openfoam
      - name: Cache OpenFOAM
        uses: actions/cache/save@v4
        with:
          path: |
            build/openfoam.tar.xz
          key: OpenFOAM-compressed
      - name: Delete OpenFOAM files (too large for artifact)
        run: |
          rm -rf build/openfoam*

# In run-test job
      - name: Use cached OpenFOAM
        uses: actions/cache/restore@v4
        with:
          path: |
            build/openfoam.tar.xz
          key: OpenFOAM-compressed
      - name: Extract cached OpenFOAM
        run: |
          tar -xJf build/openfoam.tar.xz -C build/
```
However, this takes over 17 minutes and thus, since OpenFOAM is built and cached every time, would add a considerable amount of total runtime to the workflow.  
(One might consider only building OpenFOAM if no cached version is available, which requires a modification of `tools/build-couette.py`.)
