### PR TITLE
Allow plotting in cases with more than 6 coupling cells in MD region

### DIFF
--- a/tools/plotting/plot-couette-profiles.py
+++ b/tools/plotting/plot-couette-profiles.py
@@ -50,10 +50,8 @@ def load_avg_ux_from_csv(csv_file):
     # get Avg x velocity per z layer
     avg_ux = []
     idx_col = "I01_z"
-    for i in range(4, 10):
+    for i in range(df[idx_col].min(), df[idx_col].max() + 1):
         avg = 0
-        mass = 0
-        j = 0
         for _, row in df[df[idx_col] == i].iterrows():
             avg += row["vel_x"]
         if df[df[idx_col] == i].shape[0] > 0:


### PR DESCRIPTION
The earlier script only read the cells between 4 and 9 inclusive, and thus wasn't flexible for smaller coupling cell sizes and larger domains. This fixes the reading function to allow for that flexibility.

I also removed two unused variables.