### PR TITLE
Remove nonint floats in linspace

### DIFF
--- a/tools/plotting/plot-couette-profiles.py
+++ b/tools/plotting/plot-couette-profiles.py
@@ -67,7 +67,9 @@ def plot_couette_profile(coupling_cycle, color, args, ax=plt.gca()):
         return
     data = load_avg_ux_from_csv(csv_path)
     z = np.linspace(
-        0, args.channel_height, num=(args.channel_height / args.coupling_cell_size) + 1
+        0,
+        args.channel_height,
+        num=int(args.channel_height / args.coupling_cell_size) + 1,
     )
     y = couette_analytic(
         z, coupling_cycle * args.md_ts_per_cc * args.md_ts_length, args


### PR DESCRIPTION
The code runs `num=int(args.channel_height / args.coupling_cell_size) + 1` for points in linspace. in the case that args.coupling_cell_size is a float, this results in a float value, which causes an error. This will never be a float value, since the number of cells in a dimension cannot be fractional. So we can safely force the value to be an int.