### PR TITLE
Fixed NLM Index Type

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -49,8 +49,6 @@ jobs:
           key: OpenFOAM-${{ env.OPEN_FOAM_VERSION }}
       - name: Build couette executable
         run: |
-          source scl_source enable gcc-toolset-9 || :
-          ml mpi || :
           ./tools/build-couette.py \
             --force-gcc \
             --jobs $(($(nproc --all) / 2)) \

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -6,7 +6,7 @@ on:
       - master
 
 env:
-  OPEN_FOAM_VERSION: "2206"
+  OPEN_FOAM_VERSION: "2606"
   LAMMPS_REPO_REF: "release"
 
 # Abort running jobs if a new one is triggered

--- a/coupling/filtering/sequencing/FilterJunction.cpph
+++ b/coupling/filtering/sequencing/FilterJunction.cpph
@@ -104,8 +104,9 @@ int coupling::filtering::FilterJunction<dim, inputc>::loadFiltersFromXML(
       }
 
       // Instantiation
-      newjunctor = new coupling::filtering::NLM<dim, coupling::indexing::IndexTrait::local>(inputCellVector[inputp_unfiltered], inputCellVector[inputp_prefiltered], outputCellVector[outputp],
-                                                     coupling::filtering::FilterSequence<dim>::_filteredValues, tws, sigsq, sigsq_rel, hsq, hsq_rel);
+      newjunctor = new coupling::filtering::NLM<dim, coupling::indexing::IndexTrait::local>(
+          inputCellVector[inputp_unfiltered], inputCellVector[inputp_prefiltered], outputCellVector[outputp],
+          coupling::filtering::FilterSequence<dim>::_filteredValues, tws, sigsq, sigsq_rel, hsq, hsq_rel);
 
       // TODO: generalize this for arbitrary junctors?
       // Swapping for output partition

--- a/coupling/filtering/sequencing/FilterJunction.cpph
+++ b/coupling/filtering/sequencing/FilterJunction.cpph
@@ -104,7 +104,7 @@ int coupling::filtering::FilterJunction<dim, inputc>::loadFiltersFromXML(
       }
 
       // Instantiation
-      newjunctor = new coupling::filtering::NLM<dim>(inputCellVector[inputp_unfiltered], inputCellVector[inputp_prefiltered], outputCellVector[outputp],
+      newjunctor = new coupling::filtering::NLM<dim, coupling::indexing::IndexTrait::local>(inputCellVector[inputp_unfiltered], inputCellVector[inputp_prefiltered], outputCellVector[outputp],
                                                      coupling::filtering::FilterSequence<dim>::_filteredValues, tws, sigsq, sigsq_rel, hsq, hsq_rel);
 
       // TODO: generalize this for arbitrary junctors?

--- a/coupling/scenario/main_couette.cpp
+++ b/coupling/scenario/main_couette.cpp
@@ -23,18 +23,27 @@ void runScenario(Scenario* scenario) {
 }
 
 int main(int argc, char* argv[]) {
-
+  int rank = 0;
+  int size = 1;
 #if (COUPLING_MD_PARALLEL == COUPLING_MD_YES)
   MPI_Init(&argc, &argv);
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
 #endif
 
   Kokkos::ScopeGuard kokkos(argc, argv);
   MainExecSpace mainExecSpace;
+if (rank == 0) {
+  std::cout << std::endl;
+#if (COUPLING_MD_PARALLEL == COUPLING_MD_YES)
+  std::cout << "(Printing Kokkos configuration on rank " << rank << " out of " << size << ")" << std::endl;
+#endif
   std::cout << "Kokkos using execution space \"" << mainExecSpace.name() << "\" with memory space \"" << MainExecSpace::memory_space::name() << "\""
             << std::endl;
   mainExecSpace.print_configuration(std::cout);
 
-  std::cout << "Available concurrency: " << mainExecSpace.concurrency() << std::endl;
+  std::cout << "Available concurrency: " << mainExecSpace.concurrency() << std::endl << std::endl;
+}
 
   // run scenarios
   runScenario(new CouetteScenario());

--- a/coupling/scenario/main_couette.cpp
+++ b/coupling/scenario/main_couette.cpp
@@ -33,17 +33,17 @@ int main(int argc, char* argv[]) {
 
   Kokkos::ScopeGuard kokkos(argc, argv);
   MainExecSpace mainExecSpace;
-if (rank == 0) {
-  std::cout << std::endl;
+  if (rank == 0) {
+    std::cout << std::endl;
 #if (COUPLING_MD_PARALLEL == COUPLING_MD_YES)
-  std::cout << "(Printing Kokkos configuration on rank " << rank << " out of " << size << ")" << std::endl;
+    std::cout << "(Printing Kokkos configuration on rank " << rank << " out of " << size << ")" << std::endl;
 #endif
-  std::cout << "Kokkos using execution space \"" << mainExecSpace.name() << "\" with memory space \"" << MainExecSpace::memory_space::name() << "\""
-            << std::endl;
-  mainExecSpace.print_configuration(std::cout);
+    std::cout << "Kokkos using execution space \"" << mainExecSpace.name() << "\" with memory space \"" << MainExecSpace::memory_space::name() << "\""
+              << std::endl;
+    mainExecSpace.print_configuration(std::cout);
 
-  std::cout << "Available concurrency: " << mainExecSpace.concurrency() << std::endl << std::endl;
-}
+    std::cout << "Available concurrency: " << mainExecSpace.concurrency() << std::endl << std::endl;
+  }
 
   // run scenarios
   runScenario(new CouetteScenario());

--- a/simplemd/services/ParallelTopologyService.cpp
+++ b/simplemd/services/ParallelTopologyService.cpp
@@ -265,7 +265,7 @@ simplemd::services::ParallelTopologyService::broadcastInnerCellViaBuffer(LinkedC
               // seek out current index for buffering
               int bufferIndex = getCurrentBufferIndexFromNeighbourRank(neighbourRank);
 #if (MD_DEBUG == MD_YES)
-              std::cout << "Pack " << cell.getList().size() << " molecules in buffer " << bufferIndex << std::endl;
+              std::cout << "Pack " << cell.numMolecules() << " molecules in buffer " << bufferIndex << std::endl;
 #endif
               // push molecules into buffer
               for (auto it = cell.begin(); it != cell.end(); it++) {

--- a/tools/build-couette.py
+++ b/tools/build-couette.py
@@ -49,11 +49,11 @@ LAMMPS_REPO_REF = os.getenv("LAMMPS_REPO_REF", "release")
 
 # OpenFOAM
 OPEN_FOAM_BASE_DIR = MAMICO_BUILD_DIR / "openfoam"
-OPEN_FOAM_VERSION = os.getenv("OPEN_FOAM_VERSION", "2206")
+OPEN_FOAM_VERSION = os.getenv("OPEN_FOAM_VERSION", "2606")
 OPEN_FOAM_SRC_DIR = OPEN_FOAM_BASE_DIR / f"OpenFOAM-v{OPEN_FOAM_VERSION}"
 OPEN_FOAM_URL = f"https://dl.openfoam.com/source/v{OPEN_FOAM_VERSION}/OpenFOAM-v{OPEN_FOAM_VERSION}.tgz"
 OPEN_FOAM_THIRD_PARTY_REPO_DIR = OPEN_FOAM_SRC_DIR / "ThirdParty"
-OPEN_FOAM_THIRD_PARTY_URL = "https://dl.openfoam.com/source/v2206/ThirdParty-v2206.tgz"
+OPEN_FOAM_THIRD_PARTY_URL = f"https://dl.openfoam.com/source/v{OPEN_FOAM_VERSION}/ThirdParty-v{OPEN_FOAM_VERSION}.tar.gz"
 
 
 def shell(cmd):
@@ -123,33 +123,46 @@ def download_open_foam():
     OPEN_FOAM_BASE_DIR.mkdir(exist_ok=True)
 
     def download_and_extract(url, archive_filename):
-        return 0 != shell(
-            f"wget -q -nc -O {archive_filename} {url} && tar -xzf {archive_filename} && rm {archive_filename}"
-        )
+        had_error = False
+        had_error |= 0 != shell(f"wget -q -nc -O {archive_filename} {url}")
+        if not had_error:
+            had_error |= 0 != shell(f"tar -xzf {archive_filename}")
+            if not had_error:
+                Path(archive_filename).unlink()
+        if had_error:
+            print(f"Error downloading {archive_filename} from {url}")
+        return had_error
 
     with ChangeDir(OPEN_FOAM_BASE_DIR):
         had_error |= download_and_extract(
             OPEN_FOAM_URL, f"OpenFOAM-v{OPEN_FOAM_VERSION}.tgz"
         )
     if not had_error:
-        with ChangeDir(OPEN_FOAM_SRC_DIR):
-            print(f"Downloading OpenFOAM-v{OPEN_FOAM_VERSION} third party files...")
-            had_error |= download_and_extract(
-                OPEN_FOAM_THIRD_PARTY_URL, f"ThirdParty-v{OPEN_FOAM_VERSION}.tgz"
-            )
-            if not had_error:
-                had_error = 0 != shell(f"mv ThirdParty-v{OPEN_FOAM_VERSION} ThirdParty")
+        if OPEN_FOAM_SRC_DIR.is_dir():
+            with ChangeDir(OPEN_FOAM_SRC_DIR):
+                print(f"Downloading OpenFOAM-v{OPEN_FOAM_VERSION} third party files...")
+                had_error |= download_and_extract(
+                    OPEN_FOAM_THIRD_PARTY_URL, f"ThirdParty-v{OPEN_FOAM_VERSION}.tgz"
+                )
+                if not had_error:
+                    had_error = 0 != shell(f"mv ThirdParty-v{OPEN_FOAM_VERSION} ThirdParty")
+        else:
+            had_error = True
+    if had_error:
+        shutil.rmtree(OPEN_FOAM_SRC_DIR, ignore_errors=True)
     return had_error
 
 
 def build_open_foam(jobs=8):
     print("Building OpenFOAM from source...")
     had_error = False
-    if not OPEN_FOAM_BASE_DIR.exists():
+    if not OPEN_FOAM_SRC_DIR.exists():
         had_error |= download_open_foam()
         if had_error:
-            shutil.rmtree(OPEN_FOAM_BASE_DIR)
+            shutil.rmtree(OPEN_FOAM_SRC_DIR, ignore_errors=True)
             return had_error
+    else:
+        print(f"Found {OPEN_FOAM_SRC_DIR} (Skipping download.)")
     with ChangeDir(OPEN_FOAM_SRC_DIR):
         cmd_build = ""
         cmd_build += f"source {OPEN_FOAM_SRC_DIR / 'etc' / 'bashrc'};"
@@ -263,6 +276,10 @@ if __name__ == "__main__":
     arg_parser.add_argument("-g", "--force-gcc", action="store_true")
     arg_parser.add_argument("-c", "--clean", action="store_true")
     args = arg_parser.parse_args()
+
+    assert shell("cmake --version >/dev/null") == 0, "CMake not installed or loaded!"
+    if args.with_mpi:
+        assert shell("mpicxx --version >/dev/null") == 0, "MPI not installed or loaded!"
 
     exec_path = build_mamico_couette_md(
         md_solver=args.md_solver,


### PR DESCRIPTION
## What was done
- Fixed NLM index type :point_right: closes #152 (Thanks @Thinkpiet!)
- Updated OpenFOAM to v2606 (Also updated [wiki](https://github.com/HSU-HPC/MaMiCo/wiki/OpenFOAM-installation))
- Reduced Kokkos output at the start of the simulation to only occur on the root rank (Too much redundant output)
- Compared performance of OpenFOAM and LB (without filtering)

## OpenFOAM performance test
||OpenFOAM|LB|
|:---|---:|---:|
|Coupling cycles|100|100|
|Domain|$60^3$|$60^3$|
|Two-way-coupling|yes|yes*|
|Equilibration**|no|no|
|#MD|1|1|
|MPI ranks|8|8|
|Wall time|09:06|09:03|
|RMSPE to analytical|47.667%|40.017%|

*_Identical configs just for comparison_  
**_For short test (Results seemed still "good enough")_

I noticed that the performance is completely destroyed by enabling NLM, going from ~10 minutes to ~2 hours for this scenario.  
However, I think this should be handled in a separate issue/PR.  
(Update: I have created #154 to track this.)