### PR TITLE
Use login shell on self hosted runner to source .bashrc

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -28,6 +28,9 @@ jobs:
 
   build-executable:
     runs-on: minicluster
+    defaults:
+      run:
+        shell: bash -leo pipefail {0}
     strategy:
       fail-fast: false # If some versions fail to build, still build all the others
       matrix:
@@ -77,6 +80,9 @@ jobs:
     needs: [extract-tests, build-executable]
     if: "success() || failure()" # Only SOME couette binaries might have failed to build (unless canceled)
     runs-on: minicluster
+    defaults:
+      run:
+        shell: bash -leo pipefail {0}
     strategy:
       fail-fast: false # If some test cases fail, still run all the others
       matrix: ${{ fromJson(needs.extract-tests.outputs.matrix) }}


### PR DESCRIPTION
Small fix for [integration tests not finding MPI in the CI](https://github.com/HSU-HPC/MaMiCo/actions/runs/32342369427/job/96343882060#step:7:17). (s. [discussion](https://github.com/orgs/community/discussions/25407))