### PR TITLE
Add configurable Couette scenario path

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ cmake -DMD_SIM=LS1_MARDYN -DCMAKE_BUILD_TYPE=Release -DBUILD_WITH_MPI=ON -DBUILD
 * The available options and features are explained [here](https://github.com/HSU-HPC/MaMiCo/wiki/couette.xml).  
 (*Deprecated:* Some are also listed directly in the template file via XML comments, so that you can modify the configuration to suit your needs.)
 * Start the simulation by executing (sequential case) `./couette` or e.g. (MPI-parallel) `mpirun -n 8 ./couette`.
+  To use a configuration from another location, pass `--config <path>`, for example `./couette --config ../examples/couette.xml`.
 * If you get the error message 'ERROR MoleculeService::MoleculeService: Could not open file CheckpointSimpleMD_10000_reflecting_0.checkpoint!', copy the file of the same name from the 'examples' folder into your build folder.
 * Depending on the configuration, you will obtain various output files in CSV, VTK or other formats. 
 

--- a/coupling/scenario/CouetteCommandLine.h
+++ b/coupling/scenario/CouetteCommandLine.h
@@ -1,0 +1,51 @@
+// This file is part of the Mamico project. For conditions of distribution
+// and use, please see the copyright notice in Mamico's main folder, or at
+// www5.in.tum.de/mamico
+#pragma once
+
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+struct CouetteCommandLineOptions {
+  std::string configurationFile{"couette.xml"};
+  bool configurationFileSpecified{false};
+  bool showHelp{false};
+  std::vector<std::string> remainingArguments;
+};
+
+/**
+ * Extract Couette-specific command line options while retaining options for
+ * MPI and Kokkos.  The returned remaining arguments always include argv[0].
+ */
+inline CouetteCommandLineOptions parseCouetteCommandLine(const std::vector<std::string>& arguments) {
+  CouetteCommandLineOptions options;
+  if (arguments.empty())
+    return options;
+
+  options.remainingArguments.push_back(arguments.front());
+  for (std::size_t index = 1; index < arguments.size(); ++index) {
+    const std::string& argument = arguments[index];
+    if (argument == "--help" || argument == "-h") {
+      options.showHelp = true;
+    } else if (argument == "--config") {
+      if (++index == arguments.size() || arguments[index].empty())
+        throw std::invalid_argument("--config requires a non-empty path");
+      if (options.configurationFileSpecified)
+        throw std::invalid_argument("--config may only be specified once");
+      options.configurationFile = arguments[index];
+      options.configurationFileSpecified = true;
+    } else if (argument.rfind("--config=", 0) == 0) {
+      const std::string configurationFile = argument.substr(std::string("--config=").size());
+      if (configurationFile.empty())
+        throw std::invalid_argument("--config requires a non-empty path");
+      if (options.configurationFileSpecified)
+        throw std::invalid_argument("--config may only be specified once");
+      options.configurationFile = configurationFile;
+      options.configurationFileSpecified = true;
+    } else {
+      options.remainingArguments.push_back(argument);
+    }
+  }
+  return options;
+}

--- a/coupling/scenario/CouetteScenario.h
+++ b/coupling/scenario/CouetteScenario.h
@@ -34,7 +34,9 @@
 #include <chrono>
 #include <math.h>
 #include <random>
+#include <string>
 #include <sys/time.h>
+#include <utility>
 
 #if defined(LS1_MARDYN)
 #include "coupling/interface/impl/ls1/LS1MDSolverInterface.h"
@@ -69,7 +71,9 @@ using Log::global_log;
 class CouetteScenario : public Scenario {
 public:
   /** @brief simple constructor */
-  CouetteScenario() : Scenario("CouetteScenario"), _generator(std::chrono::system_clock::now().time_since_epoch().count()) {}
+  explicit CouetteScenario(std::string configurationFile = "couette.xml")
+      : Scenario("CouetteScenario"), _configurationFile(std::move(configurationFile)),
+        _generator(std::chrono::system_clock::now().time_since_epoch().count()) {}
   /** @brief a dummy destructor */
   virtual ~CouetteScenario() {}
 
@@ -162,7 +166,7 @@ protected:
   /** @brief reads the configuration from the xml file and calls
    * parseCouetteScenarioConfiguration() */
   void parseConfigurations() {
-    std::string filename("couette.xml");
+    const std::string& filename = _configurationFile;
 
     tarch::configuration::ParseConfiguration::parseConfiguration<simplemd::configurations::MolecularDynamicsConfiguration>(filename, "molecular-dynamics",
                                                                                                                            _simpleMDConfig);
@@ -291,12 +295,12 @@ protected:
       // initialise coupling cell service for multi-MD case and set single
       // cell services in each MD simulation
       _multiMDCellService = new coupling::services::MultiMDCellService<MY_LINKEDCELL, 3>(_mdSolverInterface, couetteSolverInterface, _simpleMDConfig,
-                                                                                         _mamicoConfig, "couette.xml", *_multiMDService, _tws);
+                                                                                         _mamicoConfig, _configurationFile.c_str(), *_multiMDService, _tws);
     } else {
       // initialise coupling cell service for multi-MD case and set single
       // cell services in each MD simulation
       _multiMDCellService = new coupling::services::MultiMDCellService<MY_LINKEDCELL, 3>(_mdSolverInterface, couetteSolverInterface, _simpleMDConfig,
-                                                                                         _mamicoConfig, "couette.xml", *_multiMDService);
+                                                                                         _mamicoConfig, _configurationFile.c_str(), *_multiMDService);
     }
 
     // init filtering for all md instances
@@ -1002,6 +1006,8 @@ protected:
   int _rank;
   /** @todo Piet */
   int _tws;
+  /** @brief XML configuration file used for this scenario */
+  std::string _configurationFile;
   /** @brief the config data and information for SimpleMD */
   simplemd::configurations::MolecularDynamicsConfiguration _simpleMDConfig;
   /** @brief the config data and information for MaMiCo*/

--- a/coupling/scenario/main_couette.cpp
+++ b/coupling/scenario/main_couette.cpp
@@ -5,9 +5,12 @@
 #define _MAIN_COUETTE_CPP_
 
 #include "coupling/CouplingMDDefinitions.h"
+#include "coupling/scenario/CouetteCommandLine.h"
 #include "coupling/scenario/CouetteScenario.h"
 #include <cstdlib>
 #include <iostream>
+#include <string>
+#include <vector>
 #if (COUPLING_MD_PARALLEL == COUPLING_MD_YES)
 #include <mpi.h>
 #endif
@@ -23,15 +26,39 @@ void runScenario(Scenario* scenario) {
 }
 
 int main(int argc, char* argv[]) {
+  std::vector<std::string> arguments(argv, argv + argc);
+  CouetteCommandLineOptions options;
+  try {
+    options = parseCouetteCommandLine(arguments);
+  } catch (const std::invalid_argument& error) {
+    std::cerr << "ERROR: " << error.what() << "\nUse --help for usage." << std::endl;
+    return EXIT_FAILURE;
+  }
+  if (options.showHelp) {
+    std::cout << "Usage: " << arguments.front() << " [--config <path>] [Kokkos and MPI options]\n"
+              << "\n"
+              << "  --config <path>  Read the Couette configuration from <path> instead of couette.xml.\n"
+              << "  -h, --help       Show this help message.\n";
+    return EXIT_SUCCESS;
+  }
+
+  std::vector<char*> remainingArguments;
+  remainingArguments.reserve(options.remainingArguments.size() + 1);
+  for (std::string& argument : options.remainingArguments)
+    remainingArguments.push_back(argument.data());
+  remainingArguments.push_back(nullptr);
+  int remainingArgc = static_cast<int>(options.remainingArguments.size());
+  char** remainingArgv = remainingArguments.data();
+
   int rank = 0;
   int size = 1;
 #if (COUPLING_MD_PARALLEL == COUPLING_MD_YES)
-  MPI_Init(&argc, &argv);
+  MPI_Init(&remainingArgc, &remainingArgv);
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   MPI_Comm_size(MPI_COMM_WORLD, &size);
 #endif
 
-  Kokkos::ScopeGuard kokkos(argc, argv);
+  Kokkos::ScopeGuard kokkos(remainingArgc, remainingArgv);
   MainExecSpace mainExecSpace;
   if (rank == 0) {
     std::cout << std::endl;
@@ -46,7 +73,7 @@ int main(int argc, char* argv[]) {
   }
 
   // run scenarios
-  runScenario(new CouetteScenario());
+  runScenario(new CouetteScenario(options.configurationFile));
 
 #if (COUPLING_MD_PARALLEL == COUPLING_MD_YES)
   MPI_Finalize();

--- a/test/unit/coupling/scenario/CouetteCommandLineTest.cpp
+++ b/test/unit/coupling/scenario/CouetteCommandLineTest.cpp
@@ -1,0 +1,43 @@
+#include <cppunit/TestFixture.h>
+#include <cppunit/extensions/HelperMacros.h>
+
+#include "coupling/scenario/CouetteCommandLine.h"
+
+class CouetteCommandLineTest : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(CouetteCommandLineTest);
+  CPPUNIT_TEST(testDefaultConfiguration);
+  CPPUNIT_TEST(testCustomConfigurationAndRemainingArguments);
+  CPPUNIT_TEST(testEqualsSyntax);
+  CPPUNIT_TEST(testMissingConfigurationPath);
+  CPPUNIT_TEST(testDuplicateConfiguration);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  void testDefaultConfiguration() {
+    const CouetteCommandLineOptions options = parseCouetteCommandLine({"couette"});
+    CPPUNIT_ASSERT_EQUAL(std::string("couette.xml"), options.configurationFile);
+    CPPUNIT_ASSERT_EQUAL(std::size_t{1}, options.remainingArguments.size());
+  }
+
+  void testCustomConfigurationAndRemainingArguments() {
+    const CouetteCommandLineOptions options = parseCouetteCommandLine({"couette", "--config", "configs/short-run.xml", "--kokkos-threads=2"});
+    CPPUNIT_ASSERT_EQUAL(std::string("configs/short-run.xml"), options.configurationFile);
+    CPPUNIT_ASSERT_EQUAL(std::size_t{2}, options.remainingArguments.size());
+    CPPUNIT_ASSERT_EQUAL(std::string("--kokkos-threads=2"), options.remainingArguments[1]);
+  }
+
+  void testEqualsSyntax() {
+    const CouetteCommandLineOptions options = parseCouetteCommandLine({"couette", "--config=configs/short-run.xml"});
+    CPPUNIT_ASSERT_EQUAL(std::string("configs/short-run.xml"), options.configurationFile);
+  }
+
+  void testMissingConfigurationPath() {
+    CPPUNIT_ASSERT_THROW(parseCouetteCommandLine({"couette", "--config"}), std::invalid_argument);
+  }
+
+  void testDuplicateConfiguration() {
+    CPPUNIT_ASSERT_THROW(parseCouetteCommandLine({"couette", "--config", "couette.xml", "--config", "other.xml"}), std::invalid_argument);
+  }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(CouetteCommandLineTest);


### PR DESCRIPTION
## Summary
- add `--config <path>` (and `--config=<path>`) to the Couette executable
- preserve remaining MPI/Kokkos arguments and use the selected path for both scenario reads
- add parser coverage for default, custom, equals, missing, and duplicate arguments

## Validation
- configured and built with the project's Kokkos 5.0.2 dependency
- built the `getTestNames` test target; it discovers the five new tests
- built `couette` and verified `--help` plus missing-path diagnostics

Fixes #156